### PR TITLE
Add `.asRegExp()` method to return regexp for route

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Route = require('route-parser');
 var route = new Route('/my/fancy/route/page/:page');
 route.match('/my/fancy/route/page/7') // { page: 7 }
 route.reverse({page: 3}) // -> '/my/fancy/route/page/3'
+route.asRegExp() // new RegExp(/^\/my\/fancy\/route\/page\/([^/\?]+))?(?=\?|$)/)
 ```
 ## What can I use in my routes?
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -68,5 +68,16 @@ Route.prototype.reverse = function (params) {
   return ReverseVisitor.visit(this.ast, params);
 };
 
+/**
+ * Returns a regular expression for matching the route
+ * @example
+ * var route = new Route('/route/:one/(:two)')
+ * route.asRegExp() // -> /\/route\/([^\\/\\?]+)\/(?:([^\\/\\?]+))?/
+ * @return {RegExp} The route expressed as a regular expression
+ */
+Route.prototype.asRegExp = function () {
+  var matcher = RegexpVisitor.visit(this.ast);
+  return matcher.re;
+};
 
 module.exports = Route;

--- a/test/test.js
+++ b/test/test.js
@@ -171,4 +171,55 @@ describe('Route', function () {
       );
     });
   });
+
+  describe('asRegExp', function () {
+    it('returns regexp for route without params', function () {
+      var route = RouteParser('/foo');
+      var expected = /^\/foo(?=\?|$)/;
+      var actual = route.asRegExp();
+      assert.typeOf(actual, 'regexp');
+      assert.equal(actual.toString(), expected);
+    });
+
+    it('returns regexp for route with simple params', function () {
+      var route = RouteParser('/:foo/:bar');
+      // eslint-disable-next-line no-useless-escape
+      var expected = /^\/([^/\?]+)\/([^/\?]+)(?=\?|$)/;
+      var actual = route.asRegExp();
+      assert.typeOf(actual, 'regexp');
+      if (!global.window) {
+        assert.equal(actual.toString(), expected);
+      }
+    });
+
+    it('returns regexp for route with optional params', function () {
+      var route = RouteParser('/things/(option/:first)');
+      // eslint-disable-next-line no-useless-escape
+      var expected = /^\/things\/(?:option\/([^/\?]+))?(?=\?|$)/;
+      var actual = route.asRegExp();
+      assert.typeOf(actual, 'regexp');
+      if (!global.window) {
+        assert.equal(actual.toString(), expected);
+      }
+    });
+
+    it('returns regexp for route with nested optional params', function () {
+      var route = RouteParser('/things/(option/:first(/second/:second))');
+      // eslint-disable-next-line no-useless-escape
+      var expected = /^\/things\/(?:option\/([^/\?]+)(?:\/second\/([^/\?]+))?)?(?=\?|$)/;
+      var actual = route.asRegExp();
+      assert.typeOf(actual, 'regexp');
+      if (!global.window) {
+        assert.equal(actual.toString(), expected);
+      }
+    });
+
+    it('returns regexp for route with splat', function () {
+      var route = RouteParser('/*a/foo/*b');
+      var expected = /^\/([^?]*?)\/foo\/([^?]*?)(?=\?|$)/;
+      var actual = route.asRegExp();
+      assert.typeOf(actual, 'regexp');
+      assert.equal(actual.toString(), expected);
+    });
+  });
 });


### PR DESCRIPTION
I'm using `route-parser` in my react app, and it's working great, thank you!
And my local dev server is serving 2 single-page apps using [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) to determine which one to serve based on the URL.

Thus far I've manually crafted a regexp, then moved on to writing my own route-parser route -> regexp parser, and quickly decided that was a bit silly since route-parser can give me the regular expressions.

So here I am with a PR to expose the regexp on the route.
I'm interested to know what your thoughts on this are. Personally I'm happy to continue using the regexp visitor in my code, but I'd feel better knowing that was stable/documented. I'm happy to submit a PR for docs instead.

Another solution would be to modify connect-history-api-fallback to accept a function in place of a regexp. But I'm not a direct consumer of that module. Rather I'm using webpack-dev-server, which uses that under the hood.