### PR TITLE
Escape asterisks and parantheses in routes

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -36,6 +36,20 @@ function Route(spec) {
 Route.prototype = Object.create(null);
 
 /**
+ * Escape asterisks, open parantheses and closed parantheses.
+ * This is necessary because they are valid parts of an URL
+ * but reserved characters in route-parser.
+ * @param {string} path the path to escape
+ * @return {string} The escaped path, containing %2A instead
+ * of *, %28 instead of ( and %29 instead of )
+ */
+function escape(path) {
+  return path.replace(/\*/g, '%2A')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29');
+}
+
+/**
  * Match a path against this route, returning the matched parameters if
  * it matches, false if not. Escapes asterisks in route.
  * @example
@@ -50,7 +64,7 @@ Route.prototype = Object.create(null);
  */
 Route.prototype.match = function (path) {
   var re = RegexpVisitor.visit(this.ast);
-  var escapedPath = path.replace(new RegExp('\\*', 'g'), '%2A');
+  var escapedPath = escape(path);
   var matched = re.match(escapedPath);
 
   return matched !== null ? matched : false;

--- a/lib/route.js
+++ b/lib/route.js
@@ -37,7 +37,7 @@ Route.prototype = Object.create(null);
 
 /**
  * Match a path against this route, returning the matched parameters if
- * it matches, false if not.
+ * it matches, false if not. Escapes asterisks in route.
  * @example
  * var route = new Route('/this/is/my/route')
  * route.match('/this/is/my/route') // -> {}
@@ -50,7 +50,8 @@ Route.prototype = Object.create(null);
  */
 Route.prototype.match = function (path) {
   var re = RegexpVisitor.visit(this.ast);
-  var matched = re.match(path);
+  var escapedPath = path.replace(new RegExp('\\*', 'g'), '%2A');
+  var matched = re.match(escapedPath);
 
   return matched !== null ? matched : false;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -115,6 +115,10 @@ describe('Route', function () {
       var route = RouteParser('/things/(option/:first)');
       assert.deepEqual(route.match('/things/option/bar'), { first: 'bar' });
     });
+    it('escapes parantheses in route', function () {
+      var route = RouteParser('/foo/(option/:first)');
+      assert.deepEqual(route.match('/foo/option/bar()'), { first: 'bar()' });
+    });
 
     describe('nested', function () {
       it('allows nested', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -78,6 +78,16 @@ describe('Route', function () {
       var route = RouteParser('/*a/foo/*b');
       assert.deepEqual(route.match('/zoo/woo/foo/bar/baz'), { a: 'zoo/woo', b: 'bar/baz' });
     });
+
+    it('escapes asterisk in route', function () {
+      var route = RouteParser('/foo?bar=%2Atest&*a=splat');
+      assert.deepEqual(route.match('/foo?bar=*test&marker=splat'), { a: 'marker' });
+    });
+
+    it('escapes multiple asterisks', function () {
+      var route = RouteParser('/foo?bar=%2Atest&*a=splat&foo=%2Abar');
+      assert.deepEqual(route.match('/foo?bar=*test&marker=splat&foo=*bar'), { a: 'marker' });
+    });
   });
 
   describe('mixed', function () {


### PR DESCRIPTION
This lib is truly awesome!
After using it for a while I came across a certain problem:
Asterisks and parentheses are valid components of an URL but reserved in this lib.
(Refer to [this IETF-spec]( http://www.ietf.org/rfc/rfc1738.txt))

If it was for illegal characters in the URL I would expect the user of the lib to escape them. But since those are valid characters I think the lib should take care of escaping them.