### PR TITLE
Handle '#' like '?'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ route.reverse({page: 3}) // -> '/my/fancy/route/page/3'
 
 | Example         | Description          |
 | --------------- | -------- |
-| `:name`         |  a parameter to capture from the route up to `/`, `?`, or end of string  |
-| `*splat`        |  a splat to capture from the route up to `?` or end of string |
+| `:name`         |  a parameter to capture from the route up to `/`, `?`, `#`, or end of string  |
+| `*splat`        |  a splat to capture from the route up to `?`, `#`, or end of string |
 | `()`            |  Optional group that doesn't have to be part of the query. Can contain nested optional groups, params, and splats
 | anything else   | free form literals |
 

--- a/lib/route/visitors/regexp.js
+++ b/lib/route/visitors/regexp.js
@@ -64,14 +64,14 @@ var RegexpVisitor = createVisitor({
 
   Splat: function (node) {
     return {
-      re: '([^?]*?)',
+      re: '([^?#]*?)',
       captures: [node.props.name]
     };
   },
 
   Param: function (node) {
     return {
-      re: '([^\\/\\?]+)',
+      re: '([^\\/\\?#]+)',
       captures: [node.props.name]
     };
   },
@@ -87,7 +87,7 @@ var RegexpVisitor = createVisitor({
   Root: function (node) {
     var childResult = this.visit(node.children[0]);
     return new Matcher({
-      re: new RegExp('^' + childResult.re + '(?=\\?|$)'),
+      re: new RegExp('^' + childResult.re + '(?=\\?|#|$)'),
       captures: childResult.captures
     });
   }

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,11 @@ describe('Route', function () {
       assert.ok(route.match('/foo?query'));
     });
 
+    it('should match /foo with a path of /foo#hash', function () {
+      var route = RouteParser('/foo');
+      assert.ok(route.match('/foo#hash'));
+    });
+
     it('shouldn\'t match /foo with a path of /bar/foo', function () {
       var route = RouteParser('/foo');
       assert.notOk(route.match('/bar/foo'));
@@ -55,6 +60,16 @@ describe('Route', function () {
     it('should match /users/:id with a path of /users/1', function () {
       var route = RouteParser('/users/:id');
       assert.ok(route.match('/users/1'));
+    });
+
+    it('should match /users/:id with a path of /users/1?query', function () {
+      var route = RouteParser('/users/:id');
+      assert.ok(route.match('/users/1?query'));
+    });
+
+    it('should match /users/:id with a path of /users/1#hash', function () {
+      var route = RouteParser('/users/:id');
+      assert.ok(route.match('/users/1#hash'));
     });
 
     it('should not match /users/:id with a path of /users/', function () {


### PR DESCRIPTION
The main advantage is that the hash does not accidentally become part of a `:variable`. See the commit description for examples.